### PR TITLE
fix: py3.11 Dataclasses Field Mutability Check Exception

### DIFF
--- a/query_counter/__init__.py
+++ b/query_counter/__init__.py
@@ -152,7 +152,7 @@ class QueryCounter:
     '''
 
     session: Session | None = None
-    config: QueryAnalysisConfig = QueryAnalysisConfig()
+    config: QueryAnalysisConfig = field(default_factory=QueryAnalysisConfig)
     queries: dict[int, QueryInstance] = field(default_factory=dict)
 
     def __enter__(self):


### PR DESCRIPTION
**Changes**:
* fix: Exception with the `QueryCounter.config` field's default when Python 3.11 checks for mutability (see [Python 3.11 changelog](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses)). 

Fixes #5

---

Thanks for the cool little package!